### PR TITLE
refactor(dashboard): remove redundant onMouseLeave handlers from help…

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -328,7 +328,6 @@ export default function Dashboard() {
                 <button
                   className="text-white/60 hover:text-white transition-colors p-2 rounded-lg hover:bg-white/10"
                   onMouseEnter={() => setShowHelp("commits")}
-                  onMouseLeave={() => setShowHelp(null)}
                 >
                   <svg
                     className="w-6 h-6"
@@ -542,7 +541,6 @@ export default function Dashboard() {
                 <button
                   className="text-white/60 hover:text-white transition-colors p-2 rounded-lg hover:bg-white/10"
                   onMouseEnter={() => setShowHelp("tokens")}
-                  onMouseLeave={() => setShowHelp(null)}
                 >
                   <svg
                     className="w-6 h-6"


### PR DESCRIPTION
… buttons

The onMouseLeave handlers were redundant as the help tooltip is already cleared when clicking elsewhere. This simplifies the code without changing functionality.